### PR TITLE
:pencil2: Fix reference error with document

### DIFF
--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -7,7 +7,7 @@ import { useEffect } from 'react'
 nprogress.configure({ showSpinner: false, speed: 400, minimum: 0.25 })
 
 const MyApp = ({ Component, pageProps }: AppProps) => {
-  if (typeof window !== undefined) {
+  if (typeof window === 'object') {
     nprogress.start()
   }
 


### PR DESCRIPTION
ReferenceErrorの解消

```
ReferenceError: document is not defined
    at Object.NProgress.isRendered (/Users/tongari07/private/next-ts-template/node_modules/nprogress/nprogress.js:267:5)
    at Object.NProgress.render (/Users/tongari07/private/next-ts-template/node_modules/nprogress/nprogress.js:220:19)
    at Object.NProgress.set (/Users/tongari07/private/next-ts-template/node_modules/nprogress/nprogress.js:70:30)
    at Object.NProgress.start (/Users/tongari07/private/next-ts-template/node_modules/nprogress/nprogress.js:122:38)
    at MyApp (webpack-internal:///./src/pages/_app.page.tsx:24:58)
    at renderWithHooks (/Users/tongari07/private/next-ts-template/node_modules/react-dom/cjs/react-dom-server.browser.development.js:5658:16)
    at renderIndeterminateComponent (/Users/tongari07/private/next-ts-template/node_modules/react-dom/cjs/react-dom-server.browser.development.js:5731:15)
    at renderElement (/Users/tongari07/private/next-ts-template/node_modules/react-dom/cjs/react-dom-server.browser.development.js:5946:7)
    at renderNodeDestructiveImpl (/Users/tongari07/private/next-ts-template/node_modules/react-dom/cjs/react-dom-server.browser.development.js:6104:11)
    at renderNodeDestructive (/Users/tongari07/private/next-ts-template/node_modules/react-dom/cjs/react-dom-server.browser.development.js:6076:14)
error - ReferenceError: document is not defined
    at Object.NProgress.isRendered (/Users/tongari07/private/next-ts-template/node_modules/nprogress/nprogress.js:267:5)
    at Object.NProgress.render (/Users/tongari07/private/next-ts-template/node_modules/nprogress/nprogress.js:220:19)
    at Object.NProgress.set (/Users/tongari07/private/next-ts-template/node_modules/nprogress/nprogress.js:70:30)
    at Object.NProgress.start (/Users/tongari07/private/next-ts-template/node_modules/nprogress/nprogress.js:122:38)
    at MyApp (webpack-internal:///./src/pages/_app.page.tsx:24:58)
    at renderWithHooks (/Users/tongari07/private/next-ts-template/node_modules/react-dom/cjs/react-dom-server.browser.development.js:5658:16)
    at renderIndeterminateComponent (/Users/tongari07/private/next-ts-template/node_modules/react-dom/cjs/react-dom-server.browser.development.js:5731:15)
    at renderElement (/Users/tongari07/private/next-ts-template/node_modules/react-dom/cjs/react-dom-server.browser.development.js:5946:7)
    at renderNodeDestructiveImpl (/Users/tongari07/private/next-ts-template/node_modules/react-dom/cjs/react-dom-server.browser.development.js:6104:11)
    at renderNodeDestructive (/Users/tongari07/private/next-ts-template/node_modules/react-dom/cjs/react-dom-server.browser.development.js:6076:14) {
  page: '/'
}
warn  - Fast Refresh had to perform a full reload. Read more: https://nextjs.org/docs/basic-features/fast-refresh#how-it-works
error - uncaughtException: ReferenceError: document is not defined
    at Object.NProgress.isRendered (/Users/tongari07/private/next-ts-template/node_modules/nprogress/nprogress.js:267:5)
    at Object.NProgress.render (/Users/tongari07/private/next-ts-template/node_modules/nprogress/nprogress.js:220:19)
    at Object.NProgress.set (/Users/tongari07/private/next-ts-template/node_modules/nprogress/nprogress.js:70:30)
    at Object.NProgress.inc (/Users/tongari07/private/next-ts-template/node_modules/nprogress/nprogress.js:170:24)
    at Object.NProgress.trickle (/Users/tongari07/private/next-ts-template/node_modules/nprogress/nprogress.js:175:22)
    at Timeout._onTimeout (/Users/tongari07/private/next-ts-template/node_modules/nprogress/nprogress.js:127:19)
    at listOnTimeout (node:internal/timers:557:17)
    at processTimers (node:internal/timers:500:7)
error - uncaughtException: ReferenceError: document is not defined
    at Object.NProgress.isRendered (/Users/tongari07/private/next-ts-template/node_modules/nprogress/nprogress.js:267:5)
    at Object.NProgress.render (/Users/tongari07/private/next-ts-template/node_modules/nprogress/nprogress.js:220:19)
    at Object.NProgress.set (/Users/tongari07/private/next-ts-template/node_modules/nprogress/nprogress.js:70:30)
    at Object.NProgress.inc (/Users/tongari07/private/next-ts-template/node_modules/nprogress/nprogress.js:170:24)
    at Object.NProgress.trickle (/Users/tongari07/private/next-ts-template/node_modules/nprogress/nprogress.js:175:22)
    at Timeout._onTimeout (/Users/tongari07/private/next-ts-template/node_modules/nprogress/nprogress.js:127:19)
    at listOnTimeout (node:internal/timers:557:17)
    at processTimers (node:internal/timers:500:7)
```